### PR TITLE
Removes redundant parameter.

### DIFF
--- a/signed-commit/action.yml
+++ b/signed-commit/action.yml
@@ -26,7 +26,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-
     - name: Set github token for the target repository
       run: |
         echo "GITHUB_TOKEN=${{ inputs.github_token }}" >> $GITHUB_ENV

--- a/signed-commit/action.yml
+++ b/signed-commit/action.yml
@@ -22,21 +22,14 @@ inputs:
   remote_repository_path:
     description: "Path to the remote repository's local git directory"
     required: false
-  terraform_github_token:
-    description: "GitHub token for accessing the remote repository"
-    required: false
 
 runs:
   using: "composite"
   steps:
-    - name: Set github token for remote repository if required
+
+    - name: Set github token for the target repository
       run: |
-        echo "===== Set github token for remote repository if required ====="
-        if [ ! -z "${{ inputs.remote_repository_path }}" ]; then
-          echo "GITHUB_TOKEN=${{ inputs.terraform_github_token }}" >> $GITHUB_ENV
-        else
-          echo "GITHUB_TOKEN=${{ inputs.github_token }}" >> $GITHUB_ENV
-        fi
+        echo "GITHUB_TOKEN=${{ inputs.github_token }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Check for changes


### PR DESCRIPTION
Removes redundant parameter as the `github_token` variable can be used for either local and remote repositories given that the action only supports changes to one github repository.