### PR TITLE
Use uppercase environment variable for consistency

### DIFF
--- a/.github/workflows/aws-secrets-management.yml
+++ b/.github/workflows/aws-secrets-management.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set outputs
         id: encrypt-outputs
         run: |
-          modernisation_pat_multirepo=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$modernisation_pat_multirepo") | base64 -w0)
+          modernisation_pat_multirepo=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$MODERNISATION_PAT_MULTIREPO") | base64 -w0)
           echo "modernisation_pat_multirepo=$modernisation_pat_multirepo" >> $GITHUB_OUTPUT
 
           gov_uk_notify_api_key=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$GOV_UK_NOTIFY_API_KEY") | base64 -w0)

--- a/decrypt-secrets/action.yml
+++ b/decrypt-secrets/action.yml
@@ -32,55 +32,53 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Decrypt Secrets
-      shell: bash
-      run: |
-        if [ -n "${{ inputs.modernisation_pat_multirepo }}" ]; then
-        modernisation_pat_multirepo_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.modernisation_pat_multirepo }}" | base64 --decode))
-        echo "::add-mask::$modernisation_pat_multirepo_decrypt"
-        echo "If a value has been set for modernisation_pat_multirepo_decrypt then display it here.... $modernisation_pat_multirepo_decrypt"
-        echo "MODERNISATION_PAT_MULTIREPO=$modernisation_pat_multirepo" >> $GITHUB_ENV
-        echo "If a value has been set for MODERNISATION_PAT_MULTIREPO then display it here.... $MODERNISATION_PAT_MULTIREPO"
-        fi
+  - name: Decrypt Secrets
+    shell: bash
+    run: |
+      if [ -n "${{ inputs.modernisation_pat_multirepo }}" ]; then
+      modernisation_pat_multirepo_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.modernisation_pat_multirepo }}" | base64 --decode))
+      echo "::add-mask::$modernisation_pat_multirepo_decrypt"
+      echo "MODERNISATION_PAT_MULTIREPO=$modernisation_pat_multirepo_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.gov_uk_notify_api_key }}" ]; then
-        gov_uk_notify_api_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.gov_uk_notify_api_key }}" | base64 --decode))
-        echo "::add-mask::$gov_uk_notify_api_key_decrypt"
-        echo "GOV_UK_NOTIFY_API_KEY=$gov_uk_notify_api_key" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.gov_uk_notify_api_key }}" ]; then
+      gov_uk_notify_api_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.gov_uk_notify_api_key }}" | base64 --decode))
+      echo "::add-mask::$gov_uk_notify_api_key_decrypt"
+      echo "GOV_UK_NOTIFY_API_KEY=$gov_uk_notify_api_key_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.environment_management }}" ]; then
-        environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
-        echo "::add-mask::$environment_management_decrypt"
-        echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.environment_management }}" ]; then
+      environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
+      echo "::add-mask::$environment_management_decrypt"
+      echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.pagerduty_token }}" ]; then
-        pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
-        echo "::add-mask::$pagerduty_token_decrypt"
-        echo "PAGERDUTY_TOKEN=$pagerduty_token_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.pagerduty_token }}" ]; then
+      pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
+      echo "::add-mask::$pagerduty_token_decrypt"
+      echo "PAGERDUTY_TOKEN=$pagerduty_token_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
-        pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
-        echo "::add-mask::$pagerduty_userapi_token_decrypt"
-        echo "PAGERDUTY_USERAPI_TOKEN=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
+      pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
+      echo "::add-mask::$pagerduty_userapi_token_decrypt"
+      echo "PAGERDUTY_USERAPI_TOKEN=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.slack_webhooks }}" ]; then
-        slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhooks }}" | base64 --decode))
-        echo "::add-mask::$slack_webhooks_decrypt"
-        echo "SLACK_WEBHOOKS=$slack_webhooks_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.slack_webhooks }}" ]; then
+      slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhooks }}" | base64 --decode))
+      echo "::add-mask::$slack_webhooks_decrypt"
+      echo "SLACK_WEBHOOKS=$slack_webhooks_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.slack_webhook_url }}" ]; then
-        slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
-        echo "::add-mask::$slack_webhook_url_decrypt"
-        echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.slack_webhook_url }}" ]; then
+      slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
+      echo "::add-mask::$slack_webhook_url_decrypt"
+      echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.terraform_github_token }}" ]; then
-        terraform_github_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.terraform_github_token }}" | base64 --decode))
-        echo "::add-mask::$terraform_github_token_decrypt"
-        echo "TERRAFORM_GITHUB_TOKEN=$terraform_github_token_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.terraform_github_token }}" ]; then
+      terraform_github_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.terraform_github_token }}" | base64 --decode))
+      echo "::add-mask::$terraform_github_token_decrypt"
+      echo "TERRAFORM_GITHUB_TOKEN=$terraform_github_token_decrypt" >> $GITHUB_ENV
+      fi

--- a/decrypt-secrets/action.yml
+++ b/decrypt-secrets/action.yml
@@ -32,53 +32,55 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Decrypt Secrets
-      shell: bash
-      run: |
-        if [ -n "${{ inputs.modernisation_pat_multirepo }}" ]; then
-        modernisation_pat_multirepo_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.modernisation_pat_multirepo }}" | base64 --decode))
-        echo "::add-mask::$modernisation_pat_multirepo_decrypt"
-        echo "MODERNISATION_PAT_MULTIREPO=$modernisation_pat_multirepo" >> $GITHUB_ENV
-        fi
+  - name: Decrypt Secrets
+    shell: bash
+    run: |
+      if [ -n "${{ inputs.modernisation_pat_multirepo }}" ]; then
+      modernisation_pat_multirepo_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.modernisation_pat_multirepo }}" | base64 --decode))
+      echo "::add-mask::$modernisation_pat_multirepo_decrypt"
+      echo "If a value has been set for modernisation_pat_multirepo_decrypt then display it here.... $modernisation_pat_multirepo_decrypt"
+      echo "MODERNISATION_PAT_MULTIREPO=$modernisation_pat_multirepo" >> $GITHUB_ENV
+      echo "If a value has been set for MODERNISATION_PAT_MULTIREPO then display it here.... $MODERNISATION_PAT_MULTIREPO"
+      fi
 
-        if [ -n "${{ inputs.gov_uk_notify_api_key }}" ]; then
-        gov_uk_notify_api_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.gov_uk_notify_api_key }}" | base64 --decode))
-        echo "::add-mask::$gov_uk_notify_api_key_decrypt"
-        echo "GOV_UK_NOTIFY_API_KEY=$gov_uk_notify_api_key" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.gov_uk_notify_api_key }}" ]; then
+      gov_uk_notify_api_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.gov_uk_notify_api_key }}" | base64 --decode))
+      echo "::add-mask::$gov_uk_notify_api_key_decrypt"
+      echo "GOV_UK_NOTIFY_API_KEY=$gov_uk_notify_api_key" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.environment_management }}" ]; then
-        environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
-        echo "::add-mask::$environment_management_decrypt"
-        echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.environment_management }}" ]; then
+      environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
+      echo "::add-mask::$environment_management_decrypt"
+      echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.pagerduty_token }}" ]; then
-        pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
-        echo "::add-mask::$pagerduty_token_decrypt"
-        echo "PAGERDUTY_TOKEN=$pagerduty_token_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.pagerduty_token }}" ]; then
+      pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
+      echo "::add-mask::$pagerduty_token_decrypt"
+      echo "PAGERDUTY_TOKEN=$pagerduty_token_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
-        pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
-        echo "::add-mask::$pagerduty_userapi_token_decrypt"
-        echo "PAGERDUTY_USERAPI_TOKEN=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
+      pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
+      echo "::add-mask::$pagerduty_userapi_token_decrypt"
+      echo "PAGERDUTY_USERAPI_TOKEN=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.slack_webhooks }}" ]; then
-        slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhooks }}" | base64 --decode))
-        echo "::add-mask::$slack_webhooks_decrypt"
-        echo "SLACK_WEBHOOKS=$slack_webhooks_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.slack_webhooks }}" ]; then
+      slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhooks }}" | base64 --decode))
+      echo "::add-mask::$slack_webhooks_decrypt"
+      echo "SLACK_WEBHOOKS=$slack_webhooks_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.slack_webhook_url }}" ]; then
-        slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
-        echo "::add-mask::$slack_webhook_url_decrypt"
-        echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.slack_webhook_url }}" ]; then
+      slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
+      echo "::add-mask::$slack_webhook_url_decrypt"
+      echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.terraform_github_token }}" ]; then
-        terraform_github_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.terraform_github_token }}" | base64 --decode))
-        echo "::add-mask::$terraform_github_token_decrypt"
-        echo "TERRAFORM_GITHUB_TOKEN=$terraform_github_token_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.terraform_github_token }}" ]; then
+      terraform_github_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.terraform_github_token }}" | base64 --decode))
+      echo "::add-mask::$terraform_github_token_decrypt"
+      echo "TERRAFORM_GITHUB_TOKEN=$terraform_github_token_decrypt" >> $GITHUB_ENV
+      fi

--- a/decrypt-secrets/action.yml
+++ b/decrypt-secrets/action.yml
@@ -32,55 +32,55 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: Decrypt Secrets
-    shell: bash
-    run: |
-      if [ -n "${{ inputs.modernisation_pat_multirepo }}" ]; then
-      modernisation_pat_multirepo_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.modernisation_pat_multirepo }}" | base64 --decode))
-      echo "::add-mask::$modernisation_pat_multirepo_decrypt"
-      echo "If a value has been set for modernisation_pat_multirepo_decrypt then display it here.... $modernisation_pat_multirepo_decrypt"
-      echo "MODERNISATION_PAT_MULTIREPO=$modernisation_pat_multirepo" >> $GITHUB_ENV
-      echo "If a value has been set for MODERNISATION_PAT_MULTIREPO then display it here.... $MODERNISATION_PAT_MULTIREPO"
-      fi
+    - name: Decrypt Secrets
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.modernisation_pat_multirepo }}" ]; then
+        modernisation_pat_multirepo_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.modernisation_pat_multirepo }}" | base64 --decode))
+        echo "::add-mask::$modernisation_pat_multirepo_decrypt"
+        echo "If a value has been set for modernisation_pat_multirepo_decrypt then display it here.... $modernisation_pat_multirepo_decrypt"
+        echo "MODERNISATION_PAT_MULTIREPO=$modernisation_pat_multirepo" >> $GITHUB_ENV
+        echo "If a value has been set for MODERNISATION_PAT_MULTIREPO then display it here.... $MODERNISATION_PAT_MULTIREPO"
+        fi
 
-      if [ -n "${{ inputs.gov_uk_notify_api_key }}" ]; then
-      gov_uk_notify_api_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.gov_uk_notify_api_key }}" | base64 --decode))
-      echo "::add-mask::$gov_uk_notify_api_key_decrypt"
-      echo "GOV_UK_NOTIFY_API_KEY=$gov_uk_notify_api_key" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.gov_uk_notify_api_key }}" ]; then
+        gov_uk_notify_api_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.gov_uk_notify_api_key }}" | base64 --decode))
+        echo "::add-mask::$gov_uk_notify_api_key_decrypt"
+        echo "GOV_UK_NOTIFY_API_KEY=$gov_uk_notify_api_key" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.environment_management }}" ]; then
-      environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
-      echo "::add-mask::$environment_management_decrypt"
-      echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.environment_management }}" ]; then
+        environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
+        echo "::add-mask::$environment_management_decrypt"
+        echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.pagerduty_token }}" ]; then
-      pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
-      echo "::add-mask::$pagerduty_token_decrypt"
-      echo "PAGERDUTY_TOKEN=$pagerduty_token_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.pagerduty_token }}" ]; then
+        pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
+        echo "::add-mask::$pagerduty_token_decrypt"
+        echo "PAGERDUTY_TOKEN=$pagerduty_token_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
-      pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
-      echo "::add-mask::$pagerduty_userapi_token_decrypt"
-      echo "PAGERDUTY_USERAPI_TOKEN=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
+        pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
+        echo "::add-mask::$pagerduty_userapi_token_decrypt"
+        echo "PAGERDUTY_USERAPI_TOKEN=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.slack_webhooks }}" ]; then
-      slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhooks }}" | base64 --decode))
-      echo "::add-mask::$slack_webhooks_decrypt"
-      echo "SLACK_WEBHOOKS=$slack_webhooks_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.slack_webhooks }}" ]; then
+        slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhooks }}" | base64 --decode))
+        echo "::add-mask::$slack_webhooks_decrypt"
+        echo "SLACK_WEBHOOKS=$slack_webhooks_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.slack_webhook_url }}" ]; then
-      slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
-      echo "::add-mask::$slack_webhook_url_decrypt"
-      echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.slack_webhook_url }}" ]; then
+        slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
+        echo "::add-mask::$slack_webhook_url_decrypt"
+        echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.terraform_github_token }}" ]; then
-      terraform_github_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.terraform_github_token }}" | base64 --decode))
-      echo "::add-mask::$terraform_github_token_decrypt"
-      echo "TERRAFORM_GITHUB_TOKEN=$terraform_github_token_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.terraform_github_token }}" ]; then
+        terraform_github_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.terraform_github_token }}" | base64 --decode))
+        echo "::add-mask::$terraform_github_token_decrypt"
+        echo "TERRAFORM_GITHUB_TOKEN=$terraform_github_token_decrypt" >> $GITHUB_ENV
+        fi

--- a/decrypt-secrets/action.yml
+++ b/decrypt-secrets/action.yml
@@ -32,53 +32,53 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: Decrypt Secrets
-    shell: bash
-    run: |
-      if [ -n "${{ inputs.modernisation_pat_multirepo }}" ]; then
-      modernisation_pat_multirepo_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.modernisation_pat_multirepo }}" | base64 --decode))
-      echo "::add-mask::$modernisation_pat_multirepo_decrypt"
-      echo "MODERNISATION_PAT_MULTIREPO=$modernisation_pat_multirepo_decrypt" >> $GITHUB_ENV
-      fi
+    - name: Decrypt Secrets
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.modernisation_pat_multirepo }}" ]; then
+        modernisation_pat_multirepo_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.modernisation_pat_multirepo }}" | base64 --decode))
+        echo "::add-mask::$modernisation_pat_multirepo_decrypt"
+        echo "MODERNISATION_PAT_MULTIREPO=$modernisation_pat_multirepo_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.gov_uk_notify_api_key }}" ]; then
-      gov_uk_notify_api_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.gov_uk_notify_api_key }}" | base64 --decode))
-      echo "::add-mask::$gov_uk_notify_api_key_decrypt"
-      echo "GOV_UK_NOTIFY_API_KEY=$gov_uk_notify_api_key_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.gov_uk_notify_api_key }}" ]; then
+        gov_uk_notify_api_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.gov_uk_notify_api_key }}" | base64 --decode))
+        echo "::add-mask::$gov_uk_notify_api_key_decrypt"
+        echo "GOV_UK_NOTIFY_API_KEY=$gov_uk_notify_api_key_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.environment_management }}" ]; then
-      environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
-      echo "::add-mask::$environment_management_decrypt"
-      echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.environment_management }}" ]; then
+        environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
+        echo "::add-mask::$environment_management_decrypt"
+        echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.pagerduty_token }}" ]; then
-      pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
-      echo "::add-mask::$pagerduty_token_decrypt"
-      echo "PAGERDUTY_TOKEN=$pagerduty_token_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.pagerduty_token }}" ]; then
+        pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
+        echo "::add-mask::$pagerduty_token_decrypt"
+        echo "PAGERDUTY_TOKEN=$pagerduty_token_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
-      pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
-      echo "::add-mask::$pagerduty_userapi_token_decrypt"
-      echo "PAGERDUTY_USERAPI_TOKEN=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
+        pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
+        echo "::add-mask::$pagerduty_userapi_token_decrypt"
+        echo "PAGERDUTY_USERAPI_TOKEN=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.slack_webhooks }}" ]; then
-      slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhooks }}" | base64 --decode))
-      echo "::add-mask::$slack_webhooks_decrypt"
-      echo "SLACK_WEBHOOKS=$slack_webhooks_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.slack_webhooks }}" ]; then
+        slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhooks }}" | base64 --decode))
+        echo "::add-mask::$slack_webhooks_decrypt"
+        echo "SLACK_WEBHOOKS=$slack_webhooks_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.slack_webhook_url }}" ]; then
-      slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
-      echo "::add-mask::$slack_webhook_url_decrypt"
-      echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.slack_webhook_url }}" ]; then
+        slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
+        echo "::add-mask::$slack_webhook_url_decrypt"
+        echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
+        fi
 
-      if [ -n "${{ inputs.terraform_github_token }}" ]; then
-      terraform_github_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.terraform_github_token }}" | base64 --decode))
-      echo "::add-mask::$terraform_github_token_decrypt"
-      echo "TERRAFORM_GITHUB_TOKEN=$terraform_github_token_decrypt" >> $GITHUB_ENV
-      fi
+        if [ -n "${{ inputs.terraform_github_token }}" ]; then
+        terraform_github_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.terraform_github_token }}" | base64 --decode))
+        echo "::add-mask::$terraform_github_token_decrypt"
+        echo "TERRAFORM_GITHUB_TOKEN=$terraform_github_token_decrypt" >> $GITHUB_ENV
+        fi


### PR DESCRIPTION
This PR updates the encryption step to use `MODERNISATION_PAT_MULTIREPO` instead of `modernisation_pat_multirepo`, ensuring consistency with environment variable naming conventions.

It also fixes a couple of typos when storing the decrypted secrets in `$GITHUB_ENV`