### PR TITLE
Update OIDC role to `github-actions-read-secrets` for broader repo access

### DIFF
--- a/.github/workflows/aws-secrets-management.yml
+++ b/.github/workflows/aws-secrets-management.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: "arn:aws:iam::${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}:role/github-actions"
+          role-to-assume: "arn:aws:iam::${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}:role/github-actions-read-secrets"
           role-session-name: githubactionsrolesession
           aws-region: ${{ inputs.aws_region }}
           


### PR DESCRIPTION
The current `github-actions` role is restricted to specific repositories. This has caused workflow failures in other repos that are not explicitly allowed to assume the role. The new role, `github-actions-read-secrets`, is designed to be assumable from all repositories owned by the Modernisation Platform, resolving the access issue.
