### PR TITLE
:bug: Pin Checkov version

### DIFF
--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   unzip \
   && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --upgrade pip && pip3 install --upgrade setuptools
-RUN pip3 install checkov==2.4.14
+RUN pip3 install checkov==3.2.414
 
 #Install tflint
 RUN curl https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash

--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   unzip \
   && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --upgrade pip && pip3 install --upgrade setuptools
-RUN pip3 install checkov
+RUN pip3 install checkov==2.4.14
 
 #Install tflint
 RUN curl https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash


### PR DESCRIPTION
This PR pins the `checkov` version while the `SyntaxError` issue introduced in version 3.2.415 is investigated. (https://github.com/bridgecrewio/checkov/issues/7144)