### PR TITLE
TSA - Pin latest Version

### DIFF
--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   unzip \
   && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --upgrade pip && pip3 install --upgrade setuptools
-RUN pip3 install checkov==3.2.414
+RUN pip3 install checkov
 
 #Install tflint
 RUN curl https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash

--- a/terraform-static-analysis/action.yml
+++ b/terraform-static-analysis/action.yml
@@ -53,7 +53,7 @@ inputs:
   trivy_version:
     description: "Specify the version of trivy to install"
     required: false
-    default: "v0.62.1"
+    default: "latest"
   tfsec_trivy:
     description: "Whether or not to run TF Sec or Trivy, defaults to tfsec [tfsec, trivy]"
     required: false


### PR DESCRIPTION
This PR updates `terraform-static-analysis` to use the latest versions for `checkov` and `trivy` following the resolution of some `SyntaxErrors` showing in the scan results. 