### PR TITLE
Adds `github_ci_user_environments_repo_pat` to the aws secrets mgmt workflow and decrypt-secrets action

### DIFF
--- a/.github/workflows/aws-secrets-management.yml
+++ b/.github/workflows/aws-secrets-management.yml
@@ -25,6 +25,8 @@ on:
         value: ${{ jobs.retrieve-secrets.outputs.slack_webhook_url }}
       terraform_github_token: 
         value: ${{ jobs.retrieve-secrets.outputs.terraform_github_token }}
+      github_ci_user_environments_repo_pat:
+        value: ${{ jobs.retrieve-secrets.outputs.github_ci_user_environments_repo_pat }}
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER:
         description: "Modernisation Platform Account Number"
@@ -45,6 +47,7 @@ jobs:
       slack_webhooks: ${{ steps.encrypt-outputs.outputs.slack_webhooks }}
       slack_webhook_url: ${{ steps.encrypt-outputs.outputs.slack_webhook_url }}
       terraform_github_token: ${{ steps.encrypt-outputs.outputs.terraform_github_token }}
+      github_ci_user_environments_repo_pat: ${{ steps.encrypt-outputs.outputs.github_ci_user_environments_repo_pat }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
@@ -65,6 +68,7 @@ jobs:
             SLACK_WEBHOOKS,slack_webhooks
             SLACK_WEBHOOK_URL,slack_webhook_url
             TERRAFORM_GITHUB_TOKEN,github_ci_user_pat
+            GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT,github_ci_user_environments_repo_pat
 
       - name: Set outputs
         id: encrypt-outputs
@@ -92,4 +96,7 @@ jobs:
 
           terraform_github_token=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$TERRAFORM_GITHUB_TOKEN") | base64 -w0)
           echo "terraform_github_token=$terraform_github_token" >> $GITHUB_OUTPUT
+
+          github_ci_user_environments_repo_pat=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT") | base64 -w0)
+          echo "github_ci_user_environments_repo_pat=$github_ci_user_environments_repo_pat" >> $GITHUB_OUTPUT
           

--- a/decrypt-secrets/action.yml
+++ b/decrypt-secrets/action.yml
@@ -25,6 +25,9 @@ inputs:
   terraform_github_token:
     description: "Encrypted GitHub CI user Personal Access Token"
     required: false
+  github_ci_user_environments_repo_pat:
+    description: "Encrypted GitHub CI user environments repo Personal Access Token"
+    required: false
   PASSPHRASE:
     description: "Passphrase used for GPG decryption"
     required: true
@@ -32,54 +35,60 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Decrypt Secrets
-      shell: bash
-      run: |
-        if [ -n "${{ inputs.modernisation_pat_multirepo }}" ]; then
-        modernisation_pat_multirepo_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.modernisation_pat_multirepo }}" | base64 --decode))
-        echo "::add-mask::$modernisation_pat_multirepo_decrypt"
-        echo "MODERNISATION_PAT_MULTIREPO=$modernisation_pat_multirepo_decrypt" >> $GITHUB_ENV
-        fi
+  - name: Decrypt Secrets
+    shell: bash
+    run: |
+      if [ -n "${{ inputs.modernisation_pat_multirepo }}" ]; then
+      modernisation_pat_multirepo_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.modernisation_pat_multirepo }}" | base64 --decode))
+      echo "::add-mask::$modernisation_pat_multirepo_decrypt"
+      echo "MODERNISATION_PAT_MULTIREPO=$modernisation_pat_multirepo_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.gov_uk_notify_api_key }}" ]; then
-        gov_uk_notify_api_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.gov_uk_notify_api_key }}" | base64 --decode))
-        echo "::add-mask::$gov_uk_notify_api_key_decrypt"
-        echo "GOV_UK_NOTIFY_API_KEY=$gov_uk_notify_api_key_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.gov_uk_notify_api_key }}" ]; then
+      gov_uk_notify_api_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.gov_uk_notify_api_key }}" | base64 --decode))
+      echo "::add-mask::$gov_uk_notify_api_key_decrypt"
+      echo "GOV_UK_NOTIFY_API_KEY=$gov_uk_notify_api_key_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.environment_management }}" ]; then
-        environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
-        echo "::add-mask::$environment_management_decrypt"
-        echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.environment_management }}" ]; then
+      environment_management_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.environment_management }}" | base64 --decode))
+      echo "::add-mask::$environment_management_decrypt"
+      echo "ENVIRONMENT_MANAGEMENT=$environment_management_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.pagerduty_token }}" ]; then
-        pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
-        echo "::add-mask::$pagerduty_token_decrypt"
-        echo "PAGERDUTY_TOKEN=$pagerduty_token_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.pagerduty_token }}" ]; then
+      pagerduty_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_token }}" | base64 --decode))
+      echo "::add-mask::$pagerduty_token_decrypt"
+      echo "PAGERDUTY_TOKEN=$pagerduty_token_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
-        pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
-        echo "::add-mask::$pagerduty_userapi_token_decrypt"
-        echo "PAGERDUTY_USERAPI_TOKEN=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.pagerduty_userapi_token }}" ]; then
+      pagerduty_userapi_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.pagerduty_userapi_token }}" | base64 --decode))
+      echo "::add-mask::$pagerduty_userapi_token_decrypt"
+      echo "PAGERDUTY_USERAPI_TOKEN=$pagerduty_userapi_token_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.slack_webhooks }}" ]; then
-        slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhooks }}" | base64 --decode))
-        slack_webhooks_escaped=$(echo "$slack_webhooks_decrypt" | jq -c .)
-        echo "::add-mask::$slack_webhooks_escaped"
-        echo "SLACK_WEBHOOKS=$slack_webhooks_escaped" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.slack_webhooks }}" ]; then
+      slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhooks }}" | base64 --decode))
+      slack_webhooks_escaped=$(echo "$slack_webhooks_decrypt" | jq -c .)
+      echo "::add-mask::$slack_webhooks_escaped"
+      echo "SLACK_WEBHOOKS=$slack_webhooks_escaped" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.slack_webhook_url }}" ]; then
-        slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
-        echo "::add-mask::$slack_webhook_url_decrypt"
-        echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.slack_webhook_url }}" ]; then
+      slack_webhook_url_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.slack_webhook_url }}" | base64 --decode))
+      echo "::add-mask::$slack_webhook_url_decrypt"
+      echo "SLACK_WEBHOOK_URL=$slack_webhook_url_decrypt" >> $GITHUB_ENV
+      fi
 
-        if [ -n "${{ inputs.terraform_github_token }}" ]; then
-        terraform_github_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.terraform_github_token }}" | base64 --decode))
-        echo "::add-mask::$terraform_github_token_decrypt"
-        echo "TERRAFORM_GITHUB_TOKEN=$terraform_github_token_decrypt" >> $GITHUB_ENV
-        fi
+      if [ -n "${{ inputs.terraform_github_token }}" ]; then
+      terraform_github_token_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.terraform_github_token }}" | base64 --decode))
+      echo "::add-mask::$terraform_github_token_decrypt"
+      echo "TERRAFORM_GITHUB_TOKEN=$terraform_github_token_decrypt" >> $GITHUB_ENV
+      fi
+
+      if [ -n "${{ inputs.github_ci_user_environments_repo_pat }}" ]; then
+      github_ci_user_environments_repo_pat_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.github_ci_user_environments_repo_pat }}" | base64 --decode))
+      echo "::add-mask::$github_ci_user_environments_repo_pat_decrypt"
+      echo "GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT=$github_ci_user_environments_repo_pat_decrypt" >> $GITHUB_ENV
+      fi


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10126

## What's Changed?

I've added the `github_ci_user_environments_repo_pat` secret to the aws secrets management workflow and decrypt-secrets action so that it can be retrieved in workflows in the MPE repo without needing to be refernced as a GH secret.