### PR TITLE
Adds `securityhub_slack_webhooks` to the aws secrets mgmt workflow and decrypt-secrets action

### DIFF
--- a/.github/workflows/aws-secrets-management.yml
+++ b/.github/workflows/aws-secrets-management.yml
@@ -27,6 +27,8 @@ on:
         value: ${{ jobs.retrieve-secrets.outputs.terraform_github_token }}
       github_ci_user_environments_repo_pat:
         value: ${{ jobs.retrieve-secrets.outputs.github_ci_user_environments_repo_pat }}
+      securityhub_slack_webhooks:
+        value: ${{ jobs.retrieve-secrets.outputs.securityhub_slack_webhooks }}
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER:
         description: "Modernisation Platform Account Number"
@@ -48,6 +50,7 @@ jobs:
       slack_webhook_url: ${{ steps.encrypt-outputs.outputs.slack_webhook_url }}
       terraform_github_token: ${{ steps.encrypt-outputs.outputs.terraform_github_token }}
       github_ci_user_environments_repo_pat: ${{ steps.encrypt-outputs.outputs.github_ci_user_environments_repo_pat }}
+      securityhub_slack_webhooks: ${{ steps.encrypt-outputs.outputs.securityhub_slack_webhooks }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
@@ -69,6 +72,7 @@ jobs:
             SLACK_WEBHOOK_URL,slack_webhook_url
             TERRAFORM_GITHUB_TOKEN,github_ci_user_pat
             GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT,github_ci_user_environments_repo_pat
+            SECURITYHUB_SLACK_WEBHOOKS,securityhub_slack_webhooks
 
       - name: Set outputs
         id: encrypt-outputs
@@ -99,4 +103,7 @@ jobs:
 
           github_ci_user_environments_repo_pat=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT") | base64 -w0)
           echo "github_ci_user_environments_repo_pat=$github_ci_user_environments_repo_pat" >> $GITHUB_OUTPUT
+
+          securityhub_slack_webhooks=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$SECURITYHUB_SLACK_WEBHOOKS") | base64 -w0)
+          echo "securityhub_slack_webhooks=$securityhub_slack_webhooks" >> $GITHUB_OUTPUT
           

--- a/decrypt-secrets/action.yml
+++ b/decrypt-secrets/action.yml
@@ -28,6 +28,9 @@ inputs:
   github_ci_user_environments_repo_pat:
     description: "Encrypted GitHub CI user environments repo Personal Access Token"
     required: false
+  securityhub_slack_webhooks:
+    description: "Stores Slack channel webhook URLs for sending Security Hub findings notifications"
+    required: false
   PASSPHRASE:
     description: "Passphrase used for GPG decryption"
     required: true
@@ -91,4 +94,10 @@ runs:
         github_ci_user_environments_repo_pat_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.github_ci_user_environments_repo_pat }}" | base64 --decode))
         echo "::add-mask::$github_ci_user_environments_repo_pat_decrypt"
         echo "GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT=$github_ci_user_environments_repo_pat_decrypt" >> $GITHUB_ENV
+        fi
+
+        if [ -n "${{ inputs.securityhub_slack_webhooks }}" ]; then
+        securityhub_slack_webhooks_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.securityhub_slack_webhooks }}" | base64 --decode))
+        echo "::add-mask::$securityhub_slack_webhooks_decrypt"
+        echo "SECURITYHUB_SLACK_WEBHOOKS=$securityhub_slack_webhooks_decrypt" >> $GITHUB_ENV
         fi


### PR DESCRIPTION
https://github.com/ministryofjustice/modernisation-platform/issues/10041

I've added the `securityhub_slack_webhooks` secret to the aws secrets management workflow and decrypt-secrets action so that it can be retrieved in workflows in the MP repo without needing to be refernced as a GH secret.