### PR TITLE
🔐  PR: Improve GitHub Action Security for Signed Commits

### DIFF
--- a/signed-commit/action.yml
+++ b/signed-commit/action.yml
@@ -97,7 +97,6 @@ runs:
         echo "branch_name=$branch_name" >> $GITHUB_ENV
       shell: bash
 
-
     - name: Use current branch if on a PR
       if: env.changes == 'true' && github.event_name == 'pull_request'
       run: |

--- a/signed-commit/action.yml
+++ b/signed-commit/action.yml
@@ -89,11 +89,14 @@ runs:
         branch_name="signed_commit_$date"
         git checkout -b $branch_name
         if [ ! -z "${{ inputs.remote_repository }}" ]; then
-          git remote set-url origin https://x-access-token:${{ env.GITHUB_TOKEN }}@github.com/${{ inputs.remote_repository }}.git
+          git config --global credential.helper store
+          echo "https://x-access-token:${GITHUB_TOKEN}@github.com" > ~/.git-credentials
+          git remote set-url origin https://github.com/${{ inputs.remote_repository }}.git
         fi
         git push -u origin $branch_name
         echo "branch_name=$branch_name" >> $GITHUB_ENV
       shell: bash
+
 
     - name: Use current branch if on a PR
       if: env.changes == 'true' && github.event_name == 'pull_request'

--- a/signed-commit/action.yml
+++ b/signed-commit/action.yml
@@ -94,6 +94,7 @@ runs:
           git remote set-url origin https://github.com/${{ inputs.remote_repository }}.git
         fi
         git push -u origin $branch_name
+        rm -f ~/.git-credentials
         echo "branch_name=$branch_name" >> $GITHUB_ENV
       shell: bash
 


### PR DESCRIPTION
This pull request updates the **Signed Commit Action** to use a safer and more secure approach when pushing to a remote repository.

🔒 **Key Changes**:
- Replaced inline token usage in remote URLs with Git’s credential helper for safer authentication.
- Ensured credentials are written securely to `~/.git-credentials` and scoped only to the runner session.
- Preserved existing functionality for signed commits via GitHub’s GraphQL API and optional PR creation.

✅ **Benefits**:
- Reduces the risk of token leakage in logs or command history.
- Better aligns with GitHub’s recommended practices for automation.
- Keeps the signed commit workflow stable while enhancing security.