### PR TITLE
Use URL-encoded and masked GitHub token for remote repository push

### DIFF
--- a/signed-commit/action.yml
+++ b/signed-commit/action.yml
@@ -90,7 +90,9 @@ runs:
         git checkout -b $branch_name
         if [ ! -z "${{ inputs.remote_repository }}" ]; then
           git remote set-url origin https://github.com/${{ inputs.remote_repository }}.git
-          git push -u https://x-access-token:${GITHUB_TOKEN}@github.com/${{ inputs.remote_repository }}.git $branch_name
+          encoded_token=$(python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['GITHUB_TOKEN']))")
+          echo "::add-mask::$encoded_token"
+          git push -u https://x-access-token:${encoded_token}@github.com/${{ inputs.remote_repository }}.git $branch_name
         else
           git push -u origin $branch_name
         fi


### PR DESCRIPTION
This PR updates the `Signed Commit Action` to safely handle GitHub token usage when pushing to a remote repository:

- URL-encodes the token to avoid issues with special characters
- Masks the token in logs using `::add-mask::` to prevent accidental exposure
- Ensures compatibility with tokens containing reserved URL characters (e.g. +, /, =)

This change improves security and reliability when pushing commits to external GitHub repositories using the GitHub GraphQL API.