### PR TITLE
✨ Add Reusable GitHub Actions Workflow: Code Formatter

### DIFF
--- a/format-code/README.md
+++ b/format-code/README.md
@@ -1,8 +1,8 @@
-# 🔧 GitHub Actions Code Formatter (Reusable Workflow)
+# 🔧 Code Formatter (Reusable Workflow)
 
-This is a reusable GitHub Actions workflow that runs [MegaLinter](https://megalinter.io/) to automatically lint and format your codebase. It helps enforce consistent standards and can auto-correct issues by raising pull requests.
+This is a reusable GitHub Actions workflow that runs [MegaLinter](https://megalinter.io/) to automatically lint and format your codebase. It helps enforce consistent standards and can auto-correct issues.
 
-It runs on a schedule or via manual trigger, and will open a pull request with any fixes it applies.
+This workflow runs MegaLinter only. To create pull requests with signed commits containing any fixes, you can chain this workflow with a separate [signed-commit reusable workflow](https://github.com/ministryofjustice/modernisation-platform-github-actions/signed-commit).
 
 ---
 
@@ -11,17 +11,16 @@ It runs on a schedule or via manual trigger, and will open a pull request with a
 - Powered by [MegaLinter](https://megalinter.io/), the all-in-one code linter and formatter
 - **Supports all major languages and formats**, including Terraform, Python, Markdown, JSON, YAML, etc.
 - Uses [MegaLinter flavors](https://megalinter.io/flavors/) to optimise speed and relevance
-- Automatically creates a pull request with signed commits if changes are needed
 - Fully configurable by consumers via inputs
 
 ---
 
 ## 🚀 Quick Start
 
-In your repository, create a workflow like `.github/workflows/format-code.yml`:
+Create a workflow file in your repository, for example `.github/workflows/format-code.yml`:
 
 ```yaml
-name: Format Code
+name: "Format Code: ensure code formatting guidelines are met"
 
 on:
   workflow_dispatch:
@@ -30,31 +29,28 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   format:
-    uses: ministryofjustice/modernisation-platform-github-actions/format-code@0442287e70970e2e732fbfecf17fd362d2d21dee # 3.2.6
+    uses: ministryofjustice/modernisation-platform-github-actions/format-code@v3.2.6
     with:
       flavor: terraform
-      pr_title: "Code Formatter PR"
-      pr_body: "Automated PR created by the reusable Code Formatter workflow."
 ```
 
-Replace `flavor: terraform` with another flavor if needed (see below).
+> **Note:** This workflow only runs MegaLinter. To automatically create pull requests with fixes and signed commits, chain this with the [signed-commit reusable workflow](https://github.com/ministryofjustice/modernisation-platform-github-actions).
 
 ---
 
 ## 🧬 MegaLinter Flavors
 
-This workflow supports [MegaLinter Flavors](https://megalinter.io/flavors/) to optimize performance based on your codebase.
+This workflow supports [MegaLinter Flavors](https://megalinter.io/flavors/) to optimise performance and relevance based on your codebase:
 
-| Flavor      | Description                        |
-| ----------- | ---------------------------------- |
-| `full`      | ✅ Default — all supported linters |
-| `terraform` | Optimised for Terraform codebases  |
-| `python`    | Optimised for Python projects      |
-| `light`     | Minimal linters, fastest linting   |
+| Flavor      | Description                             |
+| ----------- | --------------------------------------- |
+| `full`      | ✅ Default — runs all supported linters |
+| `terraform` | Optimised for Terraform codebases       |
+| `python`    | Optimised for Python projects           |
+| `light`     | Minimal linters, fastest linting        |
 
 You can override the default flavor like so:
 
@@ -67,44 +63,29 @@ with:
 
 ## 🧾 Inputs
 
-These inputs let you fine-tune behaviour. All are optional and have sensible defaults.
+These inputs let you fine-tune behaviour. All are optional with sensible defaults:
 
-| Name                                         | Default Value                                                                             | Description                                                                          |
-| -------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `flavor`                                     | `full`                                                                                    | MegaLinter flavor to use (e.g., `terraform`, `python`, `full`)                       |
-| `pr_title`                                   | `"GitHub Actions Code Formatter workflow"`                                                | Title of the auto-created pull request                                               |
-| `pr_body`                                    | `"This pull request includes updates from the GitHub Actions Code Formatter workflow..."` | Body of the PR                                                                       |
-| `apply_fixes`                                | `all`                                                                                     | What to fix (e.g. `none`, `all`)                                                     |
-| `apply_fixes_event`                          | `all`                                                                                     | Trigger type to apply fixes (`push`, `pull_request`, `all`)                          |
-| `apply_fixes_mode`                           | `pull_request`                                                                            | Apply fixes as `commit` or via `pull_request`                                        |
-| `disable_errors`                             | `true`                                                                                    | If `true`, warnings do not fail the job                                              |
-| `email_reporter`                             | `false`                                                                                   | If `true`, sends email reports                                                       |
-| `enable_linters`                             | `JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT`               | Comma-separated list of linters to enable                                            |
-| `validate_all_codebase`                      | `true`                                                                                    | If `true`, lints the entire codebase                                                 |
-| `yaml_prettier_filter_regex_exclude`         | `(.github/*)`                                                                             | Regex for YAML files to exclude                                                      |
-| `markdown_markdownlint_filter_regex_exclude` | `(terraform/modules/.*/.*.md)`                                                            | Regex for Markdown files to exclude                                                  |
-| `report_output_folder`                       | `""`                                                                                      | Optional output folder for MegaLinter reports. Leave empty to disable report output. |
-
----
-
-## 📁 Required File: `scripts/git-setup.sh`
-
-Your repo must include a `scripts/git-setup.sh` script to configure git (e.g., set user/email, etc.). Example content:
-
-```bash
-#!/bin/bash
-git config --global user.email "github-actions@github.com"
-git config --global user.name "github-actions"
-```
-
-This script ensures the PR commit is signed correctly.
+| Name                                         | Default Value                                                               | Description                                                                          |
+| -------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `flavor`                                     | `full`                                                                      | MegaLinter flavor to use (e.g., `terraform`, `python`, `full`)                       |
+| `apply_fixes`                                | `all`                                                                       | What to fix (e.g., `none`, `all`)                                                    |
+| `apply_fixes_event`                          | `all`                                                                       | Trigger type to apply fixes (`push`, `pull_request`, `all`)                          |
+| `apply_fixes_mode`                           | `pull_request`                                                              | Apply fixes as `commit` or via `pull_request`                                        |
+| `disable_errors`                             | `true`                                                                      | If `true`, warnings do not fail the job                                              |
+| `email_reporter`                             | `false`                                                                     | If `true`, sends email reports                                                       |
+| `enable_linters`                             | `JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT` | Comma-separated list of linters to enable                                            |
+| `validate_all_codebase`                      | `true`                                                                      | If `true`, lints the entire codebase                                                 |
+| `yaml_prettier_filter_regex_exclude`         | `(.github/*)`                                                               | Regex for YAML files to exclude                                                      |
+| `markdown_markdownlint_filter_regex_exclude` | `(terraform/modules/.*/.*.md)`                                              | Regex for Markdown files to exclude                                                  |
+| `report_output_folder`                       | `""`                                                                        | Optional output folder for MegaLinter reports. Leave empty to disable report output. |
+| `ignore_files`                               | `""`                                                                        | Optional regex or glob patterns of files to exclude                                  |
 
 ---
 
 ## 🔐 Security Notes
 
 - All action references are **pinned to specific versions** for stability and security.
-- Pull requests are created using a reusable [signed commit workflow](https://github.com/ministryofjustice/modernisation-platform-github-actions) to ensure traceability.
+- Pull requests with signed commits are created using a separate reusable [signed commit workflow](https://github.com/ministryofjustice/modernisation-platform-github-actions).
 - Uses the GitHub-provided `GITHUB_TOKEN` with limited scoped permissions.
 
 ---
@@ -114,7 +95,7 @@ This script ensures the PR commit is signed correctly.
 ```yaml
 jobs:
   format:
-    uses: ministryofjustice/modernisation-platform-github-actions/format-code@0442287e70970e2e732fbfecf17fd362d2d21dee # 3.2.6
+    uses: ministryofjustice/modernisation-platform-github-actions/format-code@v3.2.6
     with:
       flavor: python
       enable_linters: "PYTHON_PYLINT,MARKDOWN_MARKDOWNLINT"
@@ -134,6 +115,3 @@ If you want to add new defaults, linter configurations, or improvements — open
 
 - [MegaLinter Docs](https://megalinter.io/)
 - [Flavors Guide](https://megalinter.io/flavors/)
-- [Signed Commit Action](https://github.com/ministryofjustice/modernisation-platform-github-actions)
-
----

--- a/format-code/README.md
+++ b/format-code/README.md
@@ -12,6 +12,7 @@ This workflow runs MegaLinter only. To create pull requests with signed commits 
 - **Supports all major languages and formats**, including Terraform, Python, Markdown, JSON, YAML, etc.
 - Uses [MegaLinter flavors](https://megalinter.io/flavors/) to optimise speed and relevance
 - Fully configurable by consumers via inputs
+- Uploads SARIF reports to GitHub Security tab for actionable insights
 
 ---
 
@@ -29,10 +30,11 @@ on:
 
 permissions:
   contents: write
+  security-events: write
 
 jobs:
   format:
-    uses: ministryofjustice/modernisation-platform-github-actions/format-code@v3.2.6
+    uses: ministryofjustice/modernisation-platform-github-actions/format-code@0442287e70970e2e732fbfecf17fd362d2d21dee
     with:
       flavor: terraform
 ```
@@ -52,7 +54,7 @@ This workflow supports [MegaLinter Flavors](https://megalinter.io/flavors/) to o
 | `python`    | Optimised for Python projects           |
 | `light`     | Minimal linters, fastest linting        |
 
-You can override the default flavor like so:
+Override the flavor by setting the `flavor` input:
 
 ```yaml
 with:
@@ -65,28 +67,32 @@ with:
 
 These inputs let you fine-tune behaviour. All are optional with sensible defaults:
 
-| Name                                         | Default Value                                                               | Description                                                                          |
-| -------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `flavor`                                     | `full`                                                                      | MegaLinter flavor to use (e.g., `terraform`, `python`, `full`)                       |
-| `apply_fixes`                                | `all`                                                                       | What to fix (e.g., `none`, `all`)                                                    |
-| `apply_fixes_event`                          | `all`                                                                       | Trigger type to apply fixes (`push`, `pull_request`, `all`)                          |
-| `apply_fixes_mode`                           | `pull_request`                                                              | Apply fixes as `commit` or via `pull_request`                                        |
-| `disable_errors`                             | `true`                                                                      | If `true`, warnings do not fail the job                                              |
-| `email_reporter`                             | `false`                                                                     | If `true`, sends email reports                                                       |
-| `enable_linters`                             | `JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT` | Comma-separated list of linters to enable                                            |
-| `validate_all_codebase`                      | `true`                                                                      | If `true`, lints the entire codebase                                                 |
-| `yaml_prettier_filter_regex_exclude`         | `(.github/*)`                                                               | Regex for YAML files to exclude                                                      |
-| `markdown_markdownlint_filter_regex_exclude` | `(terraform/modules/.*/.*.md)`                                              | Regex for Markdown files to exclude                                                  |
-| `report_output_folder`                       | `""`                                                                        | Optional output folder for MegaLinter reports. Leave empty to disable report output. |
-| `ignore_files`                               | `""`                                                                        | Optional regex or glob patterns of files to exclude                                  |
+| Name                                         | Default Value                                                               | Description                                                                                                   |
+| -------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `flavor`                                     | `full`                                                                      | MegaLinter flavor to use                                                                                      |
+| `apply_fixes`                                | `all`                                                                       | What to fix (e.g., `none`, `all`)                                                                             |
+| `apply_fixes_event`                          | `all`                                                                       | When to apply fixes (`push`, `pull_request`, `all`)                                                           |
+| `apply_fixes_mode`                           | `pull_request`                                                              | How to apply fixes (`commit` or `pull_request`)                                                               |
+| `disable_errors`                             | `true`                                                                      | If `true`, warnings do not fail the job                                                                       |
+| `email_reporter`                             | `false`                                                                     | If `true`, sends email reports                                                                                |
+| `enable_linters`                             | `JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT` | Comma-separated list of linters to enable                                                                     |
+| `ignore_files`                               | `""`                                                                        | Regex or glob pattern of files to exclude                                                                     |
+| `markdown_markdownlint_filter_regex_exclude` | `""`                                                                        | Regex pattern to exclude specific Markdown files                                                              |
+| `report_output_folder`                       | `""`                                                                        | Optional output folder for MegaLinter reports                                                                 |
+| `validate_all_codebase`                      | `false`                                                                     | If `true`, lints the entire codebase. If left empty, it defaults to `true` on `push` or `schedule` to `main`. |
+| `yaml_prettier_filter_regex_exclude`         | `(.github/*)`                                                               | Regex pattern to exclude YAML files (default excludes GitHub configs)                                         |
+
+> If `validate_all_codebase` is not provided, it defaults to `true` on `push` or `schedule` events to the `main` branch.  
+> However, explicitly setting it to `"false"` disables full-codebase validation regardless of the event.
 
 ---
 
 ## 🔐 Security Notes
 
-- All action references are **pinned to specific versions** for stability and security.
-- Pull requests with signed commits are created using a separate reusable [signed commit workflow](https://github.com/ministryofjustice/modernisation-platform-github-actions).
-- Uses the GitHub-provided `GITHUB_TOKEN` with limited scoped permissions.
+- All actions are **pinned to specific commit SHAs** for security and stability.
+- SARIF output is uploaded to the GitHub Security tab for visibility into linting issues.
+- Pull requests with signed commits should be created using the separate [signed commit workflow](https://github.com/ministryofjustice/modernisation-platform-github-actions).
+- Uses GitHub's built-in `GITHUB_TOKEN` for minimal-scoped auth.
 
 ---
 
@@ -95,7 +101,7 @@ These inputs let you fine-tune behaviour. All are optional with sensible default
 ```yaml
 jobs:
   format:
-    uses: ministryofjustice/modernisation-platform-github-actions/format-code@v3.2.6
+    uses: ministryofjustice/modernisation-platform-github-actions/format-code@0442287e70970e2e732fbfecf17fd362d2d21dee
     with:
       flavor: python
       enable_linters: "PYTHON_PYLINT,MARKDOWN_MARKDOWNLINT"
@@ -107,7 +113,11 @@ jobs:
 
 ## 🤝 Contributing
 
-If you want to add new defaults, linter configurations, or improvements — open a PR in this repo.
+Want to improve this workflow? PRs are welcome for:
+
+- Updated linter configurations
+- Additional options or docs
+- Bug fixes or enhancements
 
 ---
 
@@ -115,3 +125,4 @@ If you want to add new defaults, linter configurations, or improvements — open
 
 - [MegaLinter Docs](https://megalinter.io/)
 - [Flavors Guide](https://megalinter.io/flavors/)
+- [SARIF Format](https://docs.github.com/en/code-security/code-scanning/working-with-code-scanning/sarif-support-for-code-scanning)

--- a/format-code/README.md
+++ b/format-code/README.md
@@ -1,0 +1,139 @@
+# 🔧 GitHub Actions Code Formatter (Reusable Workflow)
+
+This is a reusable GitHub Actions workflow that runs [MegaLinter](https://megalinter.io/) to automatically lint and format your codebase. It helps enforce consistent standards and can auto-correct issues by raising pull requests.
+
+It runs on a schedule or via manual trigger, and will open a pull request with any fixes it applies.
+
+---
+
+## ✅ Features
+
+- Powered by [MegaLinter](https://megalinter.io/), the all-in-one code linter and formatter
+- **Supports all major languages and formats**, including Terraform, Python, Markdown, JSON, YAML, etc.
+- Uses [MegaLinter flavors](https://megalinter.io/flavors/) to optimise speed and relevance
+- Automatically creates a pull request with signed commits if changes are needed
+- Fully configurable by consumers via inputs
+
+---
+
+## 🚀 Quick Start
+
+In your repository, create a workflow like `.github/workflows/format-code.yml`:
+
+```yaml
+name: Format Code
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "45 4 * * 1-5"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format:
+    uses: ministryofjustice/modernisation-platform-github-actions/format-code@0442287e70970e2e732fbfecf17fd362d2d21dee # 3.2.6
+    with:
+      flavor: terraform
+      pr_title: "Code Formatter PR"
+      pr_body: "Automated PR created by the reusable Code Formatter workflow."
+```
+
+Replace `flavor: terraform` with another flavor if needed (see below).
+
+---
+
+## 🧬 MegaLinter Flavors
+
+This workflow supports [MegaLinter Flavors](https://megalinter.io/flavors/) to optimize performance based on your codebase.
+
+| Flavor      | Description                        |
+| ----------- | ---------------------------------- |
+| `full`      | ✅ Default — all supported linters |
+| `terraform` | Optimised for Terraform codebases  |
+| `python`    | Optimised for Python projects      |
+| `light`     | Minimal linters, fastest linting   |
+
+You can override the default flavor like so:
+
+```yaml
+with:
+  flavor: python
+```
+
+---
+
+## 🧾 Inputs
+
+These inputs let you fine-tune behaviour. All are optional and have sensible defaults.
+
+| Name                                         | Default Value                                                                             | Description                                                                          |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `flavor`                                     | `full`                                                                                    | MegaLinter flavor to use (e.g., `terraform`, `python`, `full`)                       |
+| `pr_title`                                   | `"GitHub Actions Code Formatter workflow"`                                                | Title of the auto-created pull request                                               |
+| `pr_body`                                    | `"This pull request includes updates from the GitHub Actions Code Formatter workflow..."` | Body of the PR                                                                       |
+| `apply_fixes`                                | `all`                                                                                     | What to fix (e.g. `none`, `all`)                                                     |
+| `apply_fixes_event`                          | `all`                                                                                     | Trigger type to apply fixes (`push`, `pull_request`, `all`)                          |
+| `apply_fixes_mode`                           | `pull_request`                                                                            | Apply fixes as `commit` or via `pull_request`                                        |
+| `disable_errors`                             | `true`                                                                                    | If `true`, warnings do not fail the job                                              |
+| `email_reporter`                             | `false`                                                                                   | If `true`, sends email reports                                                       |
+| `enable_linters`                             | `JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT`               | Comma-separated list of linters to enable                                            |
+| `validate_all_codebase`                      | `true`                                                                                    | If `true`, lints the entire codebase                                                 |
+| `yaml_prettier_filter_regex_exclude`         | `(.github/*)`                                                                             | Regex for YAML files to exclude                                                      |
+| `markdown_markdownlint_filter_regex_exclude` | `(terraform/modules/.*/.*.md)`                                                            | Regex for Markdown files to exclude                                                  |
+| `report_output_folder`                       | `""`                                                                                      | Optional output folder for MegaLinter reports. Leave empty to disable report output. |
+
+---
+
+## 📁 Required File: `scripts/git-setup.sh`
+
+Your repo must include a `scripts/git-setup.sh` script to configure git (e.g., set user/email, etc.). Example content:
+
+```bash
+#!/bin/bash
+git config --global user.email "github-actions@github.com"
+git config --global user.name "github-actions"
+```
+
+This script ensures the PR commit is signed correctly.
+
+---
+
+## 🔐 Security Notes
+
+- All action references are **pinned to specific versions** for stability and security.
+- Pull requests are created using a reusable [signed commit workflow](https://github.com/ministryofjustice/modernisation-platform-github-actions) to ensure traceability.
+- Uses the GitHub-provided `GITHUB_TOKEN` with limited scoped permissions.
+
+---
+
+## 🛠 Example: Custom Python Setup
+
+```yaml
+jobs:
+  format:
+    uses: ministryofjustice/modernisation-platform-github-actions/format-code@0442287e70970e2e732fbfecf17fd362d2d21dee # 3.2.6
+    with:
+      flavor: python
+      enable_linters: "PYTHON_PYLINT,MARKDOWN_MARKDOWNLINT"
+      apply_fixes_mode: commit
+      apply_fixes_event: all
+```
+
+---
+
+## 🤝 Contributing
+
+If you want to add new defaults, linter configurations, or improvements — open a PR in this repo.
+
+---
+
+## 📚 Resources
+
+- [MegaLinter Docs](https://megalinter.io/)
+- [Flavors Guide](https://megalinter.io/flavors/)
+- [Signed Commit Action](https://github.com/ministryofjustice/modernisation-platform-github-actions)
+
+---

--- a/format-code/action.yml
+++ b/format-code/action.yml
@@ -1,0 +1,109 @@
+name: Code Formatter
+description: "Runs MegaLinter with signed commit + optional PR"
+author: "Aaron Robinson"
+
+on:
+  workflow_call:
+    inputs:
+      pr_title:
+        required: false
+        default: "GitHub Actions Code Formatter workflow"
+        type: string
+      pr_body:
+        required: false
+        default: |
+          This pull request includes updates from the GitHub Actions Code Formatter workflow.
+          Please review the changes and merge if everything looks good.
+        type: string
+
+      # MegaLinter config options
+      flavor:
+        required: false
+        default: "full"
+        type: string
+      apply_fixes:
+        required: false
+        default: "all"
+        type: string
+      apply_fixes_event:
+        required: false
+        default: "all"
+        type: string
+      apply_fixes_mode:
+        required: false
+        default: "pull_request"
+        type: string
+      disable_errors:
+        required: false
+        default: "true"
+        type: string
+      email_reporter:
+        required: false
+        default: "false"
+        type: string
+      enable_linters:
+        required: false
+        default: "JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT"
+        type: string
+      validate_all_codebase:
+        required: false
+        default: "true"
+        type: string
+      yaml_prettier_filter_regex_exclude:
+        required: false
+        default: "(.github/*)"
+        type: string
+      markdown_markdownlint_filter_regex_exclude:
+        required: false
+        default: ""
+        type: string
+      report_output_folder:
+        required: false
+        default: ""
+        type: string
+      ignore_files:
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format-code:
+    name: MegaLinter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare Git options
+        run: bash ./scripts/git-setup.sh
+
+      - name: Run MegaLinter
+        uses: oxsecurity/megalinter/flavors/${{ inputs.flavor }}@e08c2b05e3dbc40af4c23f41172ef1e068a7d651 # v8.8.0
+        env:
+          APPLY_FIXES: ${{ inputs.apply_fixes }}
+          APPLY_FIXES_EVENT: ${{ inputs.apply_fixes_event }}
+          APPLY_FIXES_MODE: ${{ inputs.apply_fixes_mode }}
+          DISABLE_ERRORS: ${{ inputs.disable_errors }}
+          EMAIL_REPORTER: ${{ inputs.email_reporter }}
+          ENABLE_LINTERS: ${{ inputs.enable_linters }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: ${{ inputs.validate_all_codebase }}
+          YAML_PRETTIER_FILTER_REGEX_EXCLUDE: ${{ inputs.yaml_prettier_filter_regex_exclude }}
+          MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: ${{ inputs.markdown_markdownlint_filter_regex_exclude }}
+          REPORT_OUTPUT_FOLDER: ${{ inputs.report_output_folder }}
+          FILES_TO_EXCLUDE: ${{ inputs.ignore_files }}
+
+      - name: Commit and Create PR with Signed Commit if Changes are Found
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@0442287e70970e2e732fbfecf17fd362d2d21dee # v3.2.6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: ${{ inputs.pr_title }}
+          pr_body: ${{ inputs.pr_body }}

--- a/format-code/action.yml
+++ b/format-code/action.yml
@@ -1,23 +1,11 @@
 name: Code Formatter
-description: "Runs MegaLinter with signed commit + optional PR"
+description: "Runs MegaLinter to format code and apply linting rules across the repository."
 author: "Aaron Robinson"
 
 on:
   workflow_call:
     inputs:
-      pr_title:
-        required: false
-        default: "GitHub Actions Code Formatter workflow"
-        type: string
-      pr_body:
-        required: false
-        default: |
-          This pull request includes updates from the GitHub Actions Code Formatter workflow.
-          Please review the changes and merge if everything looks good.
-        type: string
-
-      # MegaLinter config options
-      flavor:
+      flavor: 
         required: false
         default: "full"
         type: string
@@ -66,10 +54,6 @@ on:
         default: ""
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   format-code:
     name: MegaLinter
@@ -77,13 +61,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prepare Git options
-        run: bash ./scripts/git-setup.sh
 
       - name: Run MegaLinter
         uses: oxsecurity/megalinter/flavors/${{ inputs.flavor }}@e08c2b05e3dbc40af4c23f41172ef1e068a7d651 # v8.8.0
@@ -100,10 +81,3 @@ jobs:
           MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: ${{ inputs.markdown_markdownlint_filter_regex_exclude }}
           REPORT_OUTPUT_FOLDER: ${{ inputs.report_output_folder }}
           FILES_TO_EXCLUDE: ${{ inputs.ignore_files }}
-
-      - name: Commit and Create PR with Signed Commit if Changes are Found
-        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@0442287e70970e2e732fbfecf17fd362d2d21dee # v3.2.6
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_title: ${{ inputs.pr_title }}
-          pr_body: ${{ inputs.pr_body }}

--- a/format-code/action.yml
+++ b/format-code/action.yml
@@ -1,5 +1,5 @@
 name: Code Formatter
-description: "Runs MegaLinter to format code and apply linting rules across the repository."
+description: "Runs MegaLinter to format code and apply linting rules across the repository, and uploads SARIF reports to GitHub Security tab."
 author: "Aaron Robinson"
 
 on:
@@ -33,13 +33,9 @@ on:
         required: false
         default: "JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT"
         type: string
-      validate_all_codebase:
+      ignore_files:
         required: false
-        default: "true"
-        type: string
-      yaml_prettier_filter_regex_exclude:
-        required: false
-        default: "(.github/*)"
+        default: ""
         type: string
       markdown_markdownlint_filter_regex_exclude:
         required: false
@@ -49,9 +45,13 @@ on:
         required: false
         default: ""
         type: string
-      ignore_files:
+      validate_all_codebase:
         required: false
-        default: ""
+        default: "false"
+        type: string
+      yaml_prettier_filter_regex_exclude:
+        required: false
+        default: "(.github/*)"
         type: string
 
 jobs:
@@ -75,9 +75,25 @@ jobs:
           DISABLE_ERRORS: ${{ inputs.disable_errors }}
           EMAIL_REPORTER: ${{ inputs.email_reporter }}
           ENABLE_LINTERS: ${{ inputs.enable_linters }}
+          FILES_TO_EXCLUDE: ${{ inputs.ignore_files }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: ${{ inputs.validate_all_codebase }}
-          YAML_PRETTIER_FILTER_REGEX_EXCLUDE: ${{ inputs.yaml_prettier_filter_regex_exclude }}
           MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: ${{ inputs.markdown_markdownlint_filter_regex_exclude }}
           REPORT_OUTPUT_FOLDER: ${{ inputs.report_output_folder }}
-          FILES_TO_EXCLUDE: ${{ inputs.ignore_files }}
+          REPORTERS: sarif
+          VALIDATE_ALL_CODEBASE: ${{ inputs.validate_all_codebase != '' && inputs.validate_all_codebase || (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && 'true' || 'false' }}
+          YAML_PRETTIER_FILTER_REGEX_EXCLUDE: ${{ inputs.yaml_prettier_filter_regex_exclude }}
+
+      - name: Archive MegaLinter Reports
+        if: success() || failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: MegaLinter reports
+          path: |
+            megalinter-reports
+            mega-linter.log
+
+      - name: Upload SARIF to GitHub Security tab
+        if: success() || failure()
+        uses: github/codeql-action/upload-sarif@cf7e9f23492505046de9a37830c3711dd0f25bb3 # v2.16.2
+        with:
+          sarif_file: megalinter-reports/megalinter-report.sarif

--- a/format-code/action.yml
+++ b/format-code/action.yml
@@ -5,7 +5,7 @@ author: "Aaron Robinson"
 on:
   workflow_call:
     inputs:
-      flavor: 
+      flavor:
         required: false
         default: "full"
         type: string


### PR DESCRIPTION
This PR introduces a reusable GitHub Actions workflow named Code Formatter, which runs [MegaLinter](https://megalinter.io/) to automatically lint and format code, helping enforce consistent coding standards across repositories.

## ✅ Features
- ✅ Runs **MegaLinter** (pinned to a specific SHA for security and stability)
- ✅ Supports [MegaLinter flavors](https://megalinter.io/flavors/) — defaults to full, with options like terraform, python, or light

- ✅ Fully configurable via `workflow_call` inputs:
  - Enable specific linters
  - Control fix application (`apply_fixes`, `apply_fixes_mode`, `apply_fixes_event`)
  - Exclude specific files using regex filters
  - Toggle full codebase validation or just changed files
  - Optional report output directory
- ✅ Automatically uploads SARIF reports to the **GitHub Security tab**
- ✅ Archives full MegaLinter logs and reports as GitHub Actions artifacts

## 📦 Usage
This workflow can be invoked from any repository using `workflow_call`, making it easy to share consistent formatting and linting across multiple projects.