### PR TITLE
🔄 Refactor: Convert Reusable Workflow to Composite Action

### DIFF
--- a/format-code/action.yml
+++ b/format-code/action.yml
@@ -1,0 +1,102 @@
+name: "Code Formatter"
+description: "Runs MegaLinter to format code and upload SARIF reports"
+author: "Aaron Robinson"
+inputs:
+  flavor:
+    description: "MegaLinter flavor to use (default: full)"
+    required: false
+    default: "full"
+
+  apply_fixes:
+    description: "Whether to apply automatic fixes (default: all)"
+    required: false
+    default: "all"
+
+  apply_fixes_event:
+    description: "Events on which to apply fixes (default: all)"
+    required: false
+    default: "all"
+
+  apply_fixes_mode:
+    description: "Mode for applying fixes (e.g., pull_request)"
+    required: false
+    default: "pull_request"
+
+  disable_errors:
+    description: "Disable error outputs from MegaLinter"
+    required: false
+    default: "true"
+
+  email_reporter:
+    description: "Enable or disable email reports"
+    required: false
+    default: "false"
+
+  enable_linters:
+    description: "Comma-separated list of linters to enable"
+    required: false
+    default: "JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT"
+
+  ignore_files:
+    description: "File patterns to exclude from linting"
+    required: false
+    default: ""
+
+  markdown_markdownlint_filter_regex_exclude:
+    description: "Regex for excluding markdown files from markdownlint"
+    required: false
+    default: ""
+
+  report_output_folder:
+    description: "Optional folder to output MegaLinter reports to"
+    required: false
+    default: ""
+
+  validate_all_codebase:
+    description: "Whether to lint the whole codebase or just changed files"
+    required: false
+    default: "false"
+
+  yaml_prettier_filter_regex_exclude:
+    description: "Regex for excluding YAML files from prettier"
+    required: false
+    default: "(.github/*)"
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Run MegaLinter
+      uses: oxsecurity/megalinter/flavors/${{ inputs.flavor }}@v8.8.0
+      env:
+        APPLY_FIXES: ${{ inputs.apply_fixes }}
+        APPLY_FIXES_EVENT: ${{ inputs.apply_fixes_event }}
+        APPLY_FIXES_MODE: ${{ inputs.apply_fixes_mode }}
+        DISABLE_ERRORS: ${{ inputs.disable_errors }}
+        EMAIL_REPORTER: ${{ inputs.email_reporter }}
+        ENABLE_LINTERS: ${{ inputs.enable_linters }}
+        FILES_TO_EXCLUDE: ${{ inputs.ignore_files }}
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: ${{ inputs.markdown_markdownlint_filter_regex_exclude }}
+        REPORT_OUTPUT_FOLDER: ${{ inputs.report_output_folder }}
+        REPORTERS: sarif
+        VALIDATE_ALL_CODEBASE: ${{ inputs.validate_all_codebase }}
+        YAML_PRETTIER_FILTER_REGEX_EXCLUDE: ${{ inputs.yaml_prettier_filter_regex_exclude }}
+
+    - name: Archive MegaLinter Reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: MegaLinter reports
+        path: |
+          megalinter-reports
+          mega-linter.log
+
+    - name: Upload SARIF to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: megalinter-reports/megalinter-report.sarif

--- a/format-code/action.yml
+++ b/format-code/action.yml
@@ -62,7 +62,6 @@ inputs:
     required: false
     default: "(.github/*)"
 
-
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
This PR refactors the Code Formatter from a reusable workflow to a composite GitHub Action, making it easier for other teams to consume across repositories using a clean, standard uses: syntax.

## ✅ Key Changes
- 🔁 Moved code back from `.github/workflows/reusable-format-code.yml` to `format-code/action.yml`
- 🧱 Converted the implementation to a composite action, using runs: composite
- ✍️ Added description fields to all inputs to satisfy GitHub’s YAML schema and improve the GitHub UI experience
- 📦 Action now fully self-contained and reusable with:
```yaml
uses: ministryofjustice/modernisation-platform-github-actions/format-code@<ref>
```
## 🎯 Why This Change?
- Reusable workflows must be called from another workflow, making them harder to adopt across teams.
- A composite action:
  - Can be invoked directly in other repos
  - It is easier to version, maintain, and document
  - Encourages wider reuse with minimal setup