### PR TITLE
🔧 Switch to Fixed MegaLinter Flavor (terraform)

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -3,17 +3,25 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
-permissions: {}
+permissions:
+  contents: write
+  security-events: write  # needed for SARIF upload
 
 jobs:
   format-code:
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ministryofjustice/github-actions/code-formatter@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run Format Code Action
+        uses: ministryofjustice/modernisation-platform-github-actions/format-code
         with:
-            ignore-files: "README.md"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ignore_files: "README.md"
+
+      - name: Run Signed Commit Action
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "GitHub Actions Code Formatter workflow"
+          pr_body: "This pull request includes updates from the GitHub Actions Code Formatter workflow. Please review the changes and merge if everything looks good."

--- a/format-code/action.yml
+++ b/format-code/action.yml
@@ -2,11 +2,6 @@ name: "Code Formatter"
 description: "Runs MegaLinter to format code and upload SARIF reports"
 author: "Aaron Robinson"
 inputs:
-  flavor:
-    description: "MegaLinter flavor to use (default: full)"
-    required: false
-    default: "full"
-
   apply_fixes:
     description: "Whether to apply automatic fixes (default: all)"
     required: false
@@ -71,7 +66,7 @@ runs:
         fetch-depth: 0
 
     - name: Run MegaLinter
-      uses: oxsecurity/megalinter/flavors/${{ inputs.flavor }}@v8.8.0
+      uses: oxsecurity/megalinter/flavors/terraform@v8.8.0
       env:
         APPLY_FIXES: ${{ inputs.apply_fixes }}
         APPLY_FIXES_EVENT: ${{ inputs.apply_fixes_event }}


### PR DESCRIPTION
This PR updates the `format-code` composite GitHub Action to use the `terraform` MegaLinter flavor by default, hardcoded in the action. This change was made to avoid GitHub limitations with dynamic `uses:` syntax (e.g., `uses:oxsecurity/megalinter/flavors/${{ inputs.flavor }}@v8.8.0`), which is not supported in composite actions.

✅ Summary of changes:
- Removed the `flavor` input from action.yml
- Hardcoded MegaLinter to use the `terraform` flavor
- Simplifies usage for consumers of the action, as Terraform is our most common use case

This keeps the action simple and reliable for users, while still uploading SARIF reports and archiving the MegaLinter output.

I have also updated the `.github/workflows/format-code.yml` so I can test the new changes.
