### PR TITLE
Migrate `setup-container-structure-test` from github-actions to MP-github-actions

### DIFF
--- a/setup-container-structure-test/README.md
+++ b/setup-container-structure-test/README.md
@@ -1,0 +1,42 @@
+# Set Up Container Structure Test
+
+This action installs Google's [Container Structure Test](https://github.com/GoogleContainerTools/container-structure-test) tool.
+
+> [!warning]
+> Container Structure Test is not an officially supported Google project, and is currently in maintenance mode.
+> However, releases are still being created.
+
+## Usage
+
+> [!warning]
+> This action only works with versions of Container Structure Test that are released to GitHub.
+> v1.17.0 onwards.
+
+```yaml
+jobs:
+  container-structure-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Set Up Container Structure Test
+        id: setup_container_structure_test
+        uses: ministryofjustice/modernisation-platform-github-actions/setup-container-structure-test@main
+
+      - name: Run Container Structure Test
+        id: run_container_structure_test
+        run: |
+          container-structure-test ...
+```
+
+Specifying a version
+
+```yaml
+- name: Set Up Container Structure Test
+  id: setup_container_structure_test
+  uses: ministryofjustice/modernisation-platform-github-actions/setup-container-structure-test@main
+  with:
+    version: v1.17.0
+```

--- a/setup-container-structure-test/action.yml
+++ b/setup-container-structure-test/action.yml
@@ -1,0 +1,38 @@
+---
+name: Set Up Container Structure Test
+description: This action installs the Container Structure Test binary.
+
+inputs:
+  version:
+    description: The version of Container Structure Test to install.
+    required: false
+    default: "latest"
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        if [[ "$(uname --machine)" == "x86_64" ]]; then
+          export architecture="amd64"
+        elif [[ "$(uname --machine)" == "aarch64" ]]; then
+          export architecture="arm64"
+        else
+          echo "Unsupported architecture: $(uname --machine)"
+          exit 1
+        fi
+
+        if [[ "${{ inputs.version }}" == "latest" ]]; then
+          export version="$(curl --silent https://api.github.com/repos/GoogleContainerTools/container-structure-test/releases/latest | jq -r '.tag_name')"
+        else
+          export version="${{ inputs.version }}"
+        fi
+
+        mkdir --parents "${GITHUB_WORKSPACE}/.container-structure-test"
+
+        curl --fail-with-body --location --silent "https://github.com/GoogleContainerTools/container-structure-test/releases/download/${version}/container-structure-test-linux-${architecture}" \
+          --output "${GITHUB_WORKSPACE}/.container-structure-test/container-structure-test"
+
+        chmod +x "${GITHUB_WORKSPACE}/.container-structure-test/container-structure-test"
+
+        echo "${GITHUB_WORKSPACE}/.container-structure-test" >>"${GITHUB_PATH}"


### PR DESCRIPTION
This action is still used in https://github.com/ministryofjustice/observability-platform-grafana-api-key-rotator/blob/main/.github/workflows/build-test.yml so I am migrating from github-actions to our mp-github-actions repo.