### PR TITLE
Restrict GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/aws-secrets-management.yml
+++ b/.github/workflows/aws-secrets-management.yml
@@ -52,9 +52,12 @@ on:
         description: "Passphrase used for GPG decryption"
         required: true
 
+permissions: {}
 jobs:
   retrieve-secrets:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     outputs:
       gov_uk_notify_api_key: ${{ steps.encrypt-outputs.outputs.gov_uk_notify_api_key }}
       environment_management: ${{ steps.encrypt-outputs.outputs.environment_management }}


### PR DESCRIPTION
Restricted default GITHUB_TOKEN permissions as per issue https://github.com/ministryofjustice/modernisation-platform/issues/12821

Slack Thread: https://mojdt.slack.com/archives/C013RM6MFFW/p1774948897653299