### PR TITLE
Remove deprecated testing CI IAM user keys

### DIFF
--- a/.github/workflows/aws-secrets-management.yml
+++ b/.github/workflows/aws-secrets-management.yml
@@ -27,14 +27,6 @@ on:
         value: ${{ jobs.retrieve-secrets.outputs.github_ci_user_environments_repo_pat }}
       securityhub_slack_webhooks:
         value: ${{ jobs.retrieve-secrets.outputs.securityhub_slack_webhooks }}
-      # The old combined secret:
-      testing_ci_iam_user_keys:
-        value: ${{ jobs.retrieve-secrets.outputs.testing_ci_iam_user_keys }}
-      # The new split secrets:
-      testing_ci_iam_user_access_key_id:
-        value: ${{ jobs.retrieve-secrets.outputs.testing_ci_iam_user_access_key_id }}
-      testing_ci_iam_user_secret_access_key:
-        value: ${{ jobs.retrieve-secrets.outputs.testing_ci_iam_user_secret_access_key }}
       nuke_account_ids:
         value: ${{ jobs.retrieve-secrets.outputs.nuke_account_ids }}
       nuke_rebuild_account_ids:
@@ -68,11 +60,6 @@ jobs:
       terraform_github_token: ${{ steps.encrypt-outputs.outputs.terraform_github_token }}
       github_ci_user_environments_repo_pat: ${{ steps.encrypt-outputs.outputs.github_ci_user_environments_repo_pat }}
       securityhub_slack_webhooks: ${{ steps.encrypt-outputs.outputs.securityhub_slack_webhooks }}
-      # The old combined secret:
-      testing_ci_iam_user_keys: ${{ steps.encrypt-outputs.outputs.testing_ci_iam_user_keys }}
-      # The new split secrets:
-      testing_ci_iam_user_access_key_id: ${{ steps.encrypt-outputs.outputs.testing_ci_iam_user_access_key_id }}
-      testing_ci_iam_user_secret_access_key: ${{ steps.encrypt-outputs.outputs.testing_ci_iam_user_secret_access_key }}
       nuke_account_ids: ${{ steps.encrypt-outputs.outputs.nuke_account_ids }}
       nuke_rebuild_account_ids: ${{ steps.encrypt-outputs.outputs.nuke_rebuild_account_ids }}
       nuke_account_blocklist: ${{ steps.encrypt-outputs.outputs.nuke_account_blocklist }}
@@ -98,9 +85,6 @@ jobs:
             TERRAFORM_GITHUB_TOKEN,github_ci_user_pat
             GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT,github_ci_user_environments_repo_pat
             SECURITYHUB_SLACK_WEBHOOKS,securityhub_slack_webhooks
-            TESTING_CI_IAM_USER_KEYS,testing_ci_iam_user_keys
-            TESTING_CI_IAM_USER_ACCESS_KEY_ID,testing_ci_iam_user_access_key_id
-            TESTING_CI_IAM_USER_SECRET_ACCESS_KEY,testing_ci_iam_user_secret_access_key
             NUKE_ACCOUNT_IDS,nuke_account_ids
             NUKE_REBUILD_ACCOUNT_IDS,nuke_rebuild_account_ids
             NUKE_ACCOUNT_BLOCKLIST,nuke_account_blocklist
@@ -135,17 +119,6 @@ jobs:
 
           securityhub_slack_webhooks=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$SECURITYHUB_SLACK_WEBHOOKS") | base64 -w0)
           echo "securityhub_slack_webhooks=$securityhub_slack_webhooks" >> $GITHUB_OUTPUT
-
-          # Old combined secret output:
-          testing_ci_iam_user_keys=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$TESTING_CI_IAM_USER_KEYS") | base64 -w0)
-          echo "testing_ci_iam_user_keys=$testing_ci_iam_user_keys" >> $GITHUB_OUTPUT
-
-          # New split secrets outputs:
-          testing_ci_iam_user_access_key_id=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$TESTING_CI_IAM_USER_ACCESS_KEY_ID") | base64 -w0)
-          echo "testing_ci_iam_user_access_key_id=$testing_ci_iam_user_access_key_id" >> $GITHUB_OUTPUT
-
-          testing_ci_iam_user_secret_access_key=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$TESTING_CI_IAM_USER_SECRET_ACCESS_KEY") | base64 -w0)
-          echo "testing_ci_iam_user_secret_access_key=$testing_ci_iam_user_secret_access_key" >> $GITHUB_OUTPUT
 
           nuke_account_ids=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$NUKE_ACCOUNT_IDS") | base64 -w0)
           echo "nuke_account_ids=$nuke_account_ids" >> $GITHUB_OUTPUT

--- a/decrypt-secrets/action.yml
+++ b/decrypt-secrets/action.yml
@@ -28,17 +28,6 @@ inputs:
   securityhub_slack_webhooks:
     description: "Stores Slack channel webhook URLs for sending Security Hub findings notifications"
     required: false
-  # ---- Old combined secret (keep for backward compatibility) ----
-  testing_ci_iam_user_keys:
-    description: "Encrypted Testing CI IAM User Keys"
-    required: false
-  # ---- New split secrets ----
-  testing_ci_iam_user_access_key_id:
-    description: "Encrypted Testing CI IAM User Access Key ID"
-    required: false
-  testing_ci_iam_user_secret_access_key:
-    description: "Encrypted Testing CI IAM User Secret Access Key"
-    required: false
   nuke_account_ids:
     description: "Encrypted Nuke Account IDs"
     required: false
@@ -122,28 +111,6 @@ runs:
         echo "$securityhub_slack_webhooks_decrypt"
         echo 'EOF'
       } >> "$GITHUB_ENV"
-      fi
-
-      # ---- Old combined secret ----
-      if [ -n "${{ inputs.testing_ci_iam_user_keys }}" ]; then
-      testing_ci_iam_user_keys_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.testing_ci_iam_user_keys }}" | base64 --decode))
-      echo "::add-mask::$testing_ci_iam_user_keys_decrypt"
-      echo "TESTING_CI_IAM_USER_KEYS=$testing_ci_iam_user_keys_decrypt" >> $GITHUB_ENV
-      fi
-
-      # ---- New split secrets ----
-      if [ -n "${{ inputs.testing_ci_iam_user_access_key_id }}" ]; then
-        testing_ci_iam_user_access_key_id_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.testing_ci_iam_user_access_key_id }}" | base64 --decode))
-        echo "::add-mask::$testing_ci_iam_user_access_key_id_decrypt"
-        echo "AWS_ACCESS_KEY_ID=$testing_ci_iam_user_access_key_id_decrypt" >> $GITHUB_ENV
-        echo "TESTING_CI_IAM_USER_ACCESS_KEY_ID=$testing_ci_iam_user_access_key_id_decrypt" >> $GITHUB_ENV
-      fi
-
-      if [ -n "${{ inputs.testing_ci_iam_user_secret_access_key }}" ]; then
-        testing_ci_iam_user_secret_access_key_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.testing_ci_iam_user_secret_access_key }}" | base64 --decode))
-        echo "::add-mask::$testing_ci_iam_user_secret_access_key_decrypt"
-        echo "AWS_SECRET_ACCESS_KEY=$testing_ci_iam_user_secret_access_key_decrypt" >> $GITHUB_ENV
-        echo "TESTING_CI_IAM_USER_SECRET_ACCESS_KEY=$testing_ci_iam_user_secret_access_key_decrypt" >> $GITHUB_ENV
       fi
 
       if [ -n "${{ inputs.nuke_account_ids }}" ]; then


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform-security/issues/99

I'm removing any references to the `testing-ci` user/access keys etc. which has been replaced with a dedicated testing OIDC role.

## Changes

Removes all references to the testing-ci user access keys. All repos using these central actions are no longer relying on the use of these credentials.