### PR TITLE
Add new MP GitHub App Client ID secret

### DIFF
--- a/.github/workflows/aws-secrets-management.yml
+++ b/.github/workflows/aws-secrets-management.yml
@@ -35,6 +35,8 @@ on:
         value: ${{ jobs.retrieve-secrets.outputs.nuke_account_blocklist }}
       mp_github_app_private_key:
         value: ${{ jobs.retrieve-secrets.outputs.mp_github_app_private_key }}
+      mp_github_app_client_id:
+        value: ${{ jobs.retrieve-secrets.outputs.mp_github_app_client_id }}
       
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER:
@@ -64,6 +66,7 @@ jobs:
       nuke_rebuild_account_ids: ${{ steps.encrypt-outputs.outputs.nuke_rebuild_account_ids }}
       nuke_account_blocklist: ${{ steps.encrypt-outputs.outputs.nuke_account_blocklist }}
       mp_github_app_private_key: ${{ steps.encrypt-outputs.outputs.mp_github_app_private_key }}
+      mp_github_app_client_id: ${{ steps.encrypt-outputs.outputs.mp_github_app_client_id }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
@@ -89,6 +92,7 @@ jobs:
             NUKE_REBUILD_ACCOUNT_IDS,nuke_rebuild_account_ids
             NUKE_ACCOUNT_BLOCKLIST,nuke_account_blocklist
             MP_GITHUB_APP_PRIVATE_KEY,modernisation_platform_github_app_private_key
+            MP_GITHUB_APP_CLIENT_ID,modernisation_platform_github_app_client_id
 
       - name: Set outputs
         id: encrypt-outputs
@@ -131,3 +135,6 @@ jobs:
           
           mp_github_app_private_key=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$MP_GITHUB_APP_PRIVATE_KEY") | base64 -w0)
           echo "mp_github_app_private_key=$mp_github_app_private_key" >> $GITHUB_OUTPUT
+
+          mp_github_app_client_id=$(gpg --symmetric --batch --passphrase "${{ secrets.PASSPHRASE }}" --output - <(echo "$MP_GITHUB_APP_CLIENT_ID") | base64 -w0)
+          echo "mp_github_app_client_id=$mp_github_app_client_id" >> $GITHUB_OUTPUT

--- a/decrypt-secrets/action.yml
+++ b/decrypt-secrets/action.yml
@@ -37,6 +37,9 @@ inputs:
   nuke_account_blocklist:
     description: "Encrypted Nuke Account Blocklist"
     required: false
+  mp_github_app_client_id:
+    description: "Encrypted MP Github App Client ID"
+    required: false
   mp_github_app_private_key:
     description: "Encrypted MP Github App Private Key"
     required: false
@@ -129,6 +132,12 @@ runs:
       nuke_account_blocklist_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.nuke_account_blocklist }}" | base64 --decode))
       echo "::add-mask::$nuke_account_blocklist_decrypt"
       echo "NUKE_ACCOUNT_BLOCKLIST=$nuke_account_blocklist_decrypt" >> $GITHUB_ENV
+      fi
+
+      if [ -n "${{ inputs.mp_github_app_client_id }}" ]; then
+      mp_github_app_client_id_decrypt=$(gpg --decrypt --quiet --batch --passphrase "${{ inputs.PASSPHRASE }}" --output - <(echo "${{ inputs.mp_github_app_client_id }}" | base64 --decode))
+      echo "::add-mask::$mp_github_app_client_id_decrypt"
+      echo "MP_GITHUB_APP_CLIENT_ID=$mp_github_app_client_id_decrypt" >> $GITHUB_ENV
       fi
 
       # Note - use this method where the input is plain text and not json


### PR DESCRIPTION
Adding new Modernisation-Platform GitHub App Client-ID secret to resolve deprecation `warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.`

<img width="591" height="199" alt="image" src="https://github.com/user-attachments/assets/25eec23b-e979-4145-b580-e7e467e7ea22" />
