### PR TITLE
Refactor terraform-static-analysis to install Python dependencies from requirements.txt

### DIFF
--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -8,8 +8,9 @@ RUN apt-get update && apt-get install -y \
   jq \
   unzip \
   && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt /requirements.txt
 RUN pip3 install --upgrade pip && pip3 install --upgrade setuptools
-RUN pip3 install "pycares<5" "checkov==3.2.495"
+RUN pip3 install -r /requirements.txt
 
 #Install tflint
 RUN curl https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash

--- a/terraform-static-analysis/README.md
+++ b/terraform-static-analysis/README.md
@@ -38,3 +38,5 @@ jobs:
 `fetch-depth: 0` is required to get a git diff to detect changed files.
 
 `GITHUB_TOKEN` is required to write the results to the pull request. This is the built in workflow token created when you start using Actions (see [here](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)) this should have read and write permissions to write to a pull request, this can be found under `Actions` in the repository `Settings`
+
+Python dependencies for this action are managed in `requirements.txt` and installed during image build.

--- a/terraform-static-analysis/requirements.txt
+++ b/terraform-static-analysis/requirements.txt
@@ -1,0 +1,2 @@
+checkov==3.2.495
+pycares<5


### PR DESCRIPTION
**Summary**
This PR refactors the `Terraform Static Analysis` Docker action to manage Python dependencies via a requirements file, so dependency handling is explicit and easier to govern.

**Context**
This supports the [Security-148](https://github.com/ministryofjustice/modernisation-platform-security/issues/148) issue to make dependency controls clearer for tooling used by workflows that consume this action.

**What Changed**
- Added Python dependency manifest at [requirements.txt]
- Updated image build in `Dockerfile` to install dependencies from `requirements.txt` instead of inline pip package arguments
- Added documentation note in `README.md` to state where Python dependencies are managed

**Why**
- Centralises dependency declarations in a single file
- Simplifies dependency review and future automation
- Reduces drift risk between declared and installed packages

**Validation**
- Built the Docker image locally from `Dockerfile`
- Confirmed the build succeeds with pip install -r `requirements.txt`