### PR TITLE
fix: resolve ARG_MAX error in signed-commit action

### DIFF
--- a/signed-commit/action.yml
+++ b/signed-commit/action.yml
@@ -195,12 +195,13 @@ runs:
         # Read the changed files from changed_files.txt
         while IFS= read -r file; do
           if [[ -f "$file" ]]; then
-            # Base64 encode the contents of the file
-            base64_content=$(base64 < "$file" | tr -d '\n')
+            # Base64 encode the contents of the file directly to a temp file.
+            # Avoid storing in a shell variable and passing via --arg, both of
+            # which can exceed the OS ARG_MAX limit for large files.
+            base64 < "$file" | tr -d '\n' > /tmp/b64_content.txt
 
-            # Construct a JSON object for this file and append it to the additions array
-            # Use a temp file to avoid passing large variables as shell arguments (ARG_MAX)
-            jq --arg path "$file" --arg content "$base64_content" \
+            # Use --rawfile so jq reads the content from disk, not from a shell argument
+            jq --arg path "$file" --rawfile content /tmp/b64_content.txt \
               '.additions += [{ "path": $path, "contents": $content }]' \
               /tmp/files_for_commit.json > /tmp/files_for_commit_new.json
             mv /tmp/files_for_commit_new.json /tmp/files_for_commit.json

--- a/signed-commit/action.yml
+++ b/signed-commit/action.yml
@@ -189,8 +189,8 @@ runs:
         if [ -n "${{ inputs.remote_repository_path }}" ]; then
           cd "${{ inputs.remote_repository_path }}"
         fi
-        # Initialize an empty JSON object for the additions
-        files_for_commit='{"additions": []}'
+        # Initialize an empty JSON object for the additions on disk to avoid ARG_MAX limits
+        echo '{"additions": []}' > /tmp/files_for_commit.json
 
         # Read the changed files from changed_files.txt
         while IFS= read -r file; do
@@ -199,13 +199,16 @@ runs:
             base64_content=$(base64 < "$file" | tr -d '\n')
 
             # Construct a JSON object for this file and append it to the additions array
-            files_for_commit=$(echo "$files_for_commit" | jq --arg path "$file" --arg content "$base64_content" \
-              '.additions += [{ "path": $path, "contents": $content }]')
+            # Use a temp file to avoid passing large variables as shell arguments (ARG_MAX)
+            jq --arg path "$file" --arg content "$base64_content" \
+              '.additions += [{ "path": $path, "contents": $content }]' \
+              /tmp/files_for_commit.json > /tmp/files_for_commit_new.json
+            mv /tmp/files_for_commit_new.json /tmp/files_for_commit.json
           fi
         done < changed_files.txt
 
         # Output the final JSON array
-        echo "$files_for_commit" > files_for_commit.json
+        cp /tmp/files_for_commit.json files_for_commit.json
       shell: bash
 
     - name: Create signed commit using GraphQL


### PR DESCRIPTION
## Problem

The `signed-commit` action was failing with `jq: Argument list too long` (exit code 126) when building the GraphQL commit payload. Two separate issues combined to cause this:

1. The accumulated JSON payload was stored in a shell variable (`$files_for_commit`) and piped to `jq` via `echo "$files_for_commit" | jq ...`. As the variable grew with each file's base64 content, it exceeded the OS `ARG_MAX` limit.
2. Even after fixing the accumulation, individual large files still hit `ARG_MAX` because their base64 content was passed directly as a `jq` `--arg`, which is also subject to the same shell argument size limit.

## Fix

- The JSON payload is built entirely on disk using `/tmp/files_for_commit.json`, updated in-place per loop iteration.
- Each file's base64 content is written to `/tmp/b64_content.txt` and passed to `jq` via `--rawfile`, which reads directly from disk and completely bypasses shell argument size limits.

## Testing

Validated against the `modernisation-platform-environments` format-code workflow, which formats the full codebase and previously triggered the failure.