### PR TITLE
fix(terraform-static-analysis): workaround TFLint issue #2591 attestation panic

### DIFF
--- a/terraform-static-analysis/README.md
+++ b/terraform-static-analysis/README.md
@@ -39,4 +39,6 @@ jobs:
 
 `GITHUB_TOKEN` is required to write the results to the pull request. This is the built in workflow token created when you start using Actions (see [here](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)) this should have read and write permissions to write to a pull request, this can be found under `Actions` in the repository `Settings`
 
+Temporary TFLint workaround for [terraform-linters/tflint#2591](https://github.com/terraform-linters/tflint/issues/2591): bundled `tflint-configs` use `signature = "pgp"` to avoid the broken attestation verification path. Remove these `signature` settings once upstream fix [terraform-linters/tflint#2593](https://github.com/terraform-linters/tflint/pull/2593) is released and adopted.
+
 Python dependencies for this action are managed in `requirements.txt` and installed during image build.

--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -81,6 +81,12 @@ run_checkov() {
 run_tflint() {
   line_break
 
+  # Workaround for upstream tflint plugin attestation panic when GITHUB_TOKEN is set.
+  # The action still uses GITHUB_TOKEN later for PR comments.
+  run_tflint_command() {
+    env -u GITHUB_TOKEN tflint "$@"
+  }
+
   if [[ -n $INPUT_TFLINT_CONFIG ]]; then
     echo "Setting custom config ${INPUT_TFLINT_CONFIG}"
     tflint_config="/tflint-configs/${INPUT_TFLINT_CONFIG}"
@@ -89,7 +95,12 @@ run_tflint() {
     tflint_config="/tflint-configs/tflint.default.hcl"
   fi
 
-  tflint --init --config "$tflint_config"
+  run_tflint_command --init --config "$tflint_config"
+  if [[ $? -ne 0 ]]; then
+    echo "tflint --init failed"
+    tflint_exitcode=1
+    return $tflint_exitcode
+  fi
 
   echo "tflint checking:"
   echo "$1"
@@ -103,9 +114,9 @@ run_tflint() {
       if [[ -n "$INPUT_TFLINT_EXCLUDE" ]]; then
         readarray -d , -t tflint_exclusions <<<"$INPUT_TFLINT_EXCLUDE"
         tflint_exclusions_list=("${tflint_exclusions[@]/#/--disable-rule=}")
-        tflint --config "$tflint_config" ${tflint_exclusions_list[@]} --chdir "${terraform_working_dir}" --call-module-type "${INPUT_TFLINT_CALL_MODULE_TYPE}" 2>&1
+        run_tflint_command --config "$tflint_config" ${tflint_exclusions_list[@]} --chdir "${terraform_working_dir}" --call-module-type "${INPUT_TFLINT_CALL_MODULE_TYPE}" 2>&1
       else
-        tflint --config "$tflint_config" --chdir "${terraform_working_dir}" --call-module-type "${INPUT_TFLINT_CALL_MODULE_TYPE}" 2>&1
+        run_tflint_command --config "$tflint_config" --chdir "${terraform_working_dir}" --call-module-type "${INPUT_TFLINT_CALL_MODULE_TYPE}" 2>&1
       fi
     else
       echo "Skipping folder ${directory}"

--- a/terraform-static-analysis/tflint-configs/tflint.aws.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.aws.hcl
@@ -1,13 +1,13 @@
 plugin "aws" {
     enabled = true
-    version = "0.33.0"
+    version = "0.48.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
     signature = "pgp"
 }
 
 plugin "terraform" {
     enabled = true
-    version = "0.9.1"
+    version = "0.15.0"
     preset  = "recommended"
     source  = "github.com/terraform-linters/tflint-ruleset-terraform"
     signature = "pgp"

--- a/terraform-static-analysis/tflint-configs/tflint.aws.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.aws.hcl
@@ -2,6 +2,7 @@ plugin "aws" {
     enabled = true
     version = "0.33.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
+    signature = "pgp"
 }
 
 plugin "terraform" {
@@ -9,6 +10,7 @@ plugin "terraform" {
     version = "0.9.1"
     preset  = "recommended"
     source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+    signature = "pgp"
 }
 
 rule "terraform_deprecated_index" {

--- a/terraform-static-analysis/tflint-configs/tflint.azure.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.azure.hcl
@@ -2,6 +2,7 @@ plugin "azurerm" {
     enabled = true
     version = "0.27.0"
     source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+    signature = "pgp"
 }
 
 plugin "terraform" {
@@ -9,6 +10,7 @@ plugin "terraform" {
     version = "0.9.1"
     preset  = "recommended"
     source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+    signature = "pgp"
 }
 
 rule "terraform_comment_syntax" {

--- a/terraform-static-analysis/tflint-configs/tflint.azure.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.azure.hcl
@@ -1,13 +1,13 @@
 plugin "azurerm" {
     enabled = true
-    version = "0.27.0"
+    version = "0.32.0"
     source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
     signature = "pgp"
 }
 
 plugin "terraform" {
     enabled = true
-    version = "0.9.1"
+    version = "0.15.0"
     preset  = "recommended"
     source  = "github.com/terraform-linters/tflint-ruleset-terraform"
     signature = "pgp"

--- a/terraform-static-analysis/tflint-configs/tflint.default.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.default.hcl
@@ -1,6 +1,6 @@
 plugin "terraform" {
     enabled = true
-    version = "0.9.1"
+    version = "0.15.0"
     preset  = "recommended"
     source  = "github.com/terraform-linters/tflint-ruleset-terraform"
     signature = "pgp"

--- a/terraform-static-analysis/tflint-configs/tflint.default.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.default.hcl
@@ -3,6 +3,7 @@ plugin "terraform" {
     version = "0.9.1"
     preset  = "recommended"
     source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+    signature = "pgp"
 }
 
 rule "terraform_deprecated_index" {


### PR DESCRIPTION
## Summary
This PR applies a temporary workaround for https://github.com/terraform-linters/tflint/issues/2591, where `tflint --init` panics in the attestation verification path due to GitHub's API now returning `bundle: null` and only a `bundle_url` in attestation list responses.

## Changes

### Attestation panic workaround ([#2591](https://github.com/terraform-linters/tflint/issues/2591))
- Run TFLint commands with `GITHUB_TOKEN` unset in the action runtime to avoid the crashing attestation path. `GITHUB_TOKEN` is still available later for PR comments.
- Set `signature = "pgp"` in bundled TFLint plugin configs so verification uses the PGP path instead of the broken attestation path.
- Fail fast with a clear error message if `tflint --init` exits non-zero.

### Plugin version bumps
| Plugin | Old | New |
|---|---|---|
| `tflint-ruleset-aws` | `0.33.0` | `0.48.0` |
| `tflint-ruleset-azurerm` | `0.27.0` | `0.32.0` |
| `tflint-ruleset-terraform` | `0.9.1` | `0.15.0` |

Configs updated: `tflint.aws.hcl`, `tflint.azure.hcl`, `tflint.default.hcl`

### Docs
- `terraform-static-analysis/README.md` — noted the temporary `signature = "pgp"` workaround and linked to the upstream fix PR.

## Validation
- `bash -n terraform-static-analysis/entrypoint.sh` — no syntax errors.
- Editor diagnostics on all touched files — no errors.

## Follow-up
Remove the `signature = "pgp"` lines and the `env -u GITHUB_TOKEN` wrapper once the upstream fix ships:
- https://github.com/terraform-linters/tflint/pull/2593